### PR TITLE
Fix Storage Drawers Item Handlers issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,8 @@ dependencies {
     deobfProvided "curse.maven:treasure2-289760:3758107"
     deobfProvided "curse.maven:time-speed-mod-221053:2991593"
     deobfCompile "curse.maven:gregtech-ce-unofficial-557242:3745499"
+    deobfCompile "curse.maven:storage-drawers-223852:2952606" // Storage Drawers 5.4.2
+    compile "curse.maven:chameleon-230497:2450900" // Chameleon Lib4.1.3
 }
 
 processResources {

--- a/src/main/java/zone/rong/loliasm/common/modfixes/storagedrawers/mixins/ControllerDataMixin.java
+++ b/src/main/java/zone/rong/loliasm/common/modfixes/storagedrawers/mixins/ControllerDataMixin.java
@@ -22,6 +22,7 @@ public class ControllerDataMixin {
         if (controller != null) {
             if (!controller.isInvalid()) {
                 cir.setReturnValue(controller);
+                return;
             }
             controller = null;
             host.markDirty();

--- a/src/main/java/zone/rong/loliasm/common/modfixes/storagedrawers/mixins/ControllerDataMixin.java
+++ b/src/main/java/zone/rong/loliasm/common/modfixes/storagedrawers/mixins/ControllerDataMixin.java
@@ -1,0 +1,41 @@
+package zone.rong.loliasm.common.modfixes.storagedrawers.mixins;
+
+import com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController;
+import com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.ControllerData;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = ControllerData.class, remap = false)
+public class ControllerDataMixin {
+    @Shadow
+    private BlockPos controllerCoord;
+
+    private TileEntityController controller;
+
+    @Inject(method = "getController", at = @At(value = "HEAD"), cancellable = true)
+    void getController(TileEntity host, CallbackInfoReturnable<TileEntityController> cir) {
+        if (controller != null) {
+            if (!controller.isInvalid()) {
+                cir.setReturnValue(controller);
+            }
+            controller = null;
+            host.markDirty();
+            cir.setReturnValue(null);
+        }
+        if (controllerCoord != null) {
+            controller = (TileEntityController) host.getWorld().getTileEntity(controllerCoord);
+        }
+        cir.setReturnValue(controller);
+    }
+
+    @Inject(method = "bindCoord", at = @At(value = "RETURN"))
+    void bindCoord(BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
+        controller = null;
+    }
+
+}

--- a/src/main/java/zone/rong/loliasm/common/modfixes/storagedrawers/mixins/ControllerDataMixin.java
+++ b/src/main/java/zone/rong/loliasm/common/modfixes/storagedrawers/mixins/ControllerDataMixin.java
@@ -25,7 +25,6 @@ public class ControllerDataMixin {
             }
             controller = null;
             host.markDirty();
-            cir.setReturnValue(null);
         }
         if (controllerCoord != null) {
             controller = (TileEntityController) host.getWorld().getTileEntity(controllerCoord);

--- a/src/main/java/zone/rong/loliasm/common/modfixes/storagedrawers/mixins/DrawerItemHandlerMixin.java
+++ b/src/main/java/zone/rong/loliasm/common/modfixes/storagedrawers/mixins/DrawerItemHandlerMixin.java
@@ -1,0 +1,28 @@
+package zone.rong.loliasm.common.modfixes.storagedrawers.mixins;
+
+import com.jaquadro.minecraft.storagedrawers.capabilities.DrawerItemHandler;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import javax.annotation.Nonnull;
+
+@Mixin(value = DrawerItemHandler.class, remap = false)
+public class DrawerItemHandlerMixin {
+    @Inject(method = "insertItem", at = @At("HEAD"), cancellable = true)
+    public void insertItem(int slot, ItemStack stack, boolean simulate, CallbackInfoReturnable<ItemStack> cir) {
+        if (slot == 0) {
+            cir.setReturnValue(stack);
+        }
+        cir.setReturnValue(this.insertItemInternal(slot, stack, simulate));
+    }
+
+    @Shadow
+    private ItemStack insertItemInternal(int slot, @Nonnull ItemStack stack, boolean simulate) {
+        return null;
+    }
+
+}

--- a/src/main/java/zone/rong/loliasm/common/modfixes/storagedrawers/mixins/DrawerItemHandlerMixin.java
+++ b/src/main/java/zone/rong/loliasm/common/modfixes/storagedrawers/mixins/DrawerItemHandlerMixin.java
@@ -16,6 +16,7 @@ public class DrawerItemHandlerMixin {
     public void insertItem(int slot, ItemStack stack, boolean simulate, CallbackInfoReturnable<ItemStack> cir) {
         if (slot == 0) {
             cir.setReturnValue(stack);
+            return;
         }
         cir.setReturnValue(this.insertItemInternal(slot, stack, simulate));
     }

--- a/src/main/java/zone/rong/loliasm/common/modfixes/storagedrawers/mixins/FractionalDrawerGroupMixin.java
+++ b/src/main/java/zone/rong/loliasm/common/modfixes/storagedrawers/mixins/FractionalDrawerGroupMixin.java
@@ -1,0 +1,22 @@
+package zone.rong.loliasm.common.modfixes.storagedrawers.mixins;
+
+import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerAttributes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(targets = "com.jaquadro.minecraft.storagedrawers.block.tile.tiledata.FractionalDrawerGroup$FractionalStorage", remap = false)
+public class FractionalDrawerGroupMixin {
+    @Shadow
+    IDrawerAttributes attrs;
+
+    @Inject(method = {"adjustStoredItemCount"}, at = @At(value = "HEAD"), cancellable = true)
+    public void adjustStoredItemCount(int slot, int amount, CallbackInfoReturnable<Integer> cir) {
+        if (this.attrs.isUnlimitedVending()) {
+            cir.setReturnValue(0);
+        }
+    }
+
+}

--- a/src/main/java/zone/rong/loliasm/config/LoliConfig.java
+++ b/src/main/java/zone/rong/loliasm/config/LoliConfig.java
@@ -70,7 +70,7 @@ public class LoliConfig {
     public boolean releaseSpriteFramesCache, onDemandAnimatedTextures;
     public boolean optimizeSomeRendering, stripUnnecessaryLocalsInRenderHelper;
     public boolean quickerEnableUniversalBucketCheck, stripInstancedRandomFromSoundEventAccessor, classCaching, copyScreenshotToClipboard, releaseScreenshotCache, asyncScreenshot, removeExcessiveGCCalls, smoothDimensionChange;
-    public boolean fixBlockIEBaseArrayIndexOutOfBoundsException, cleanupChickenASMClassHierarchyManager, optimizeAmuletRelatedFunctions, labelCanonicalization, skipCraftTweakerRecalculatingSearchTrees, bwmBlastingOilOptimization, optimizeQMDBeamRenderer, repairEvilCraftEIOCompat, optimizeArcaneLockRendering, fixXU2CrafterCrash, disableXU2CrafterRendering, fixTFCFallingBlockFalseStartingTEPos;
+    public boolean fixBlockIEBaseArrayIndexOutOfBoundsException, cleanupChickenASMClassHierarchyManager, optimizeAmuletRelatedFunctions, labelCanonicalization, skipCraftTweakerRecalculatingSearchTrees, bwmBlastingOilOptimization, optimizeQMDBeamRenderer, repairEvilCraftEIOCompat, optimizeArcaneLockRendering, fixXU2CrafterCrash, disableXU2CrafterRendering, fixTFCFallingBlockFalseStartingTEPos, fixDrawersItemHandlers;
     public boolean fixAmuletHolderCapability, delayItemStackCapabilityInit;
     public boolean fixFillBucketEventNullPointerException, fixTileEntityOnLoadCME, removeForgeSecurityManager, fasterEntitySpawnPreparation;
     public boolean fixMC30845, fixMC31681, fixMC129057, fixMC129556, resolveMC2071, limitSkinDownloadingThreads, fixMC88176;
@@ -150,6 +150,7 @@ public class LoliConfig {
         fixXU2CrafterCrash = getBoolean("fixXU2CrafterCrash", "modfixes", "When Extra Utilities 2 is installed, fix and optimize mechanical crafter's rendering", true);
         disableXU2CrafterRendering = getBoolean("disableXU2CrafterRendering", "modfixes", "When Extra Utilities 2 is installed, disable the crafter's rendering of the item being crafted, this can reduce lag, ignores fixXU2CrafterCrash config option", false);
         fixTFCFallingBlockFalseStartingTEPos = getBoolean("fixTFCFallingBlockFalseStartingTEPos", "modfixes", "When TerraFirmaCraft is installed, fix the falling block's false starting position ", true);
+        fixDrawersItemHandlers = getBoolean("fixDrawersItemHandlers", "modfixes", "When Drawers is installed, fix the item handler issues of the Storage Drawers mod", true);
 
         fixAmuletHolderCapability = getBoolean("fixAmuletHolderCapability", "capability", "Fixes Astral Sorcery applying AmuletHolderCapability to large amount of ItemStacks when it isn't needed. This option will be ignored when Astral Sorcery isn't installed", true);
         delayItemStackCapabilityInit = getBoolean("delayItemStackCapabilityInit", "capability", "Delays ItemStack's capabilities from being initialized until they needed to be", true);

--- a/src/main/java/zone/rong/loliasm/core/LoliLateMixinLoader.java
+++ b/src/main/java/zone/rong/loliasm/core/LoliLateMixinLoader.java
@@ -47,7 +47,7 @@ public class LoliLateMixinLoader implements ILateMixinLoader {
             case "mixins.modfixes_b3m.json":
                 return LoliConfig.instance.resourceLocationCanonicalization && Loader.isModLoaded("B3M"); // Stupid
             case "mixins.modfixes_storagedrawers.json":
-                return LoliConfig.instance.fixDrawersItemHandlers && Loader.isModLoaded("StorageDrawers");
+                return LoliConfig.instance.fixDrawersItemHandlers && Loader.isModLoaded("storagedrawers");
         }
         return false;
     }

--- a/src/main/java/zone/rong/loliasm/core/LoliLateMixinLoader.java
+++ b/src/main/java/zone/rong/loliasm/core/LoliLateMixinLoader.java
@@ -20,6 +20,7 @@ public class LoliLateMixinLoader implements ILateMixinLoader {
                 "mixins.modfixes_ebwizardry.json",
                 "mixins.modfixes_xu2.json",
                 "mixins.modfixes_b3m.json",
+                "mixins.modfixes_storagedrawers.json",
                 "mixins.searchtree_mod.json");
     }
 
@@ -45,6 +46,8 @@ public class LoliLateMixinLoader implements ILateMixinLoader {
                 return LoliConfig.instance.fixAmuletHolderCapability && Loader.isModLoaded("astralsorcery");
             case "mixins.modfixes_b3m.json":
                 return LoliConfig.instance.resourceLocationCanonicalization && Loader.isModLoaded("B3M"); // Stupid
+            case "mixins.modfixes_storagedrawers.json":
+                return LoliConfig.instance.fixDrawersItemHandlers && Loader.isModLoaded("StorageDrawers");
         }
         return false;
     }

--- a/src/main/resources/mixins.modfixes_storagedrawers.json
+++ b/src/main/resources/mixins.modfixes_storagedrawers.json
@@ -1,0 +1,15 @@
+{
+  "package": "zone.rong.loliasm.common.modfixes.storagedrawers.mixins",
+  "refmap": "mixins.loliasm.refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "ControllerDataMixin",
+    "DrawerItemHandlerMixin",
+    "FractionalDrawerGroupMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
Fix voiding of items  when nearing full capacity
Fix Slotless Item handler implementation not allowing the extraction from compacting item drawers with the vending upgrade
Cache the Drawer Controller tile to avoid getting the TE from the world every time a drawer slave is interacted with (getSlots,getStackInSlot, etc.)