### PR TITLE
A couple of fixes

### DIFF
--- a/src/main/java/zone/rong/loliasm/client/sprite/ondemand/mixins/BlockModelRendererMixin.java
+++ b/src/main/java/zone/rong/loliasm/client/sprite/ondemand/mixins/BlockModelRendererMixin.java
@@ -36,14 +36,16 @@ public class BlockModelRendererMixin {
     }
 
     @SuppressWarnings("all")
-    @Inject(method = "renderQuadsFlat", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/BufferBuilder;addVertexData([I)V"), locals = LocalCapture.CAPTURE_FAILHARD)
-    private void sendAnimatedSprites$flat(IBlockAccess blockAccessIn, IBlockState stateIn, BlockPos posIn, int brightnessIn, boolean ownBrightness, BufferBuilder buffer, List<BakedQuad> list, BitSet bitSet, CallbackInfo ci, Vec3d vec3, double d0, double d1, double d2, int i, int j, BakedQuad bakedquad) {
+    @Redirect(method = "renderQuadsFlat", at = @At(value = "INVOKE", target = "Ljava/util/List;get(I)Ljava/lang/Object;", ordinal = 0))
+    private BakedQuad sendAnimatedSprites$flat(List<BakedQuad> list, int i) {
+        BakedQuad bakedquad = list.get(i);
         if (bakedquad.getSprite().hasAnimationMetadata()) {
             CompiledChunk chunk = IAnimatedSpritePrimer.CURRENT_COMPILED_CHUNK.get();
             if (chunk != CompiledChunk.DUMMY) {
                 ((ICompiledChunkExpander) chunk).resolve(bakedquad.getSprite());
             }
         }
+        return bakedquad;
     }
 
 }

--- a/src/main/java/zone/rong/loliasm/client/sprite/ondemand/mixins/BlockModelRendererMixin.java
+++ b/src/main/java/zone/rong/loliasm/client/sprite/ondemand/mixins/BlockModelRendererMixin.java
@@ -37,7 +37,7 @@ public class BlockModelRendererMixin {
 
     @SuppressWarnings("all")
     @Redirect(method = "renderQuadsFlat", at = @At(value = "INVOKE", target = "Ljava/util/List;get(I)Ljava/lang/Object;", ordinal = 0))
-    private BakedQuad sendAnimatedSprites$flat(List<BakedQuad> list, int i) {
+    private Object sendAnimatedSprites$flat(List<BakedQuad> list, int i) {
         BakedQuad bakedquad = list.get(i);
         if (bakedquad.getSprite().hasAnimationMetadata()) {
             CompiledChunk chunk = IAnimatedSpritePrimer.CURRENT_COMPILED_CHUNK.get();

--- a/src/main/java/zone/rong/loliasm/config/LoliConfig.java
+++ b/src/main/java/zone/rong/loliasm/config/LoliConfig.java
@@ -73,7 +73,7 @@ public class LoliConfig {
     public boolean fixBlockIEBaseArrayIndexOutOfBoundsException, cleanupChickenASMClassHierarchyManager, optimizeAmuletRelatedFunctions, labelCanonicalization, skipCraftTweakerRecalculatingSearchTrees, bwmBlastingOilOptimization, optimizeQMDBeamRenderer, repairEvilCraftEIOCompat, optimizeArcaneLockRendering, fixXU2CrafterCrash, disableXU2CrafterRendering, fixTFCFallingBlockFalseStartingTEPos;
     public boolean fixAmuletHolderCapability, delayItemStackCapabilityInit;
     public boolean fixFillBucketEventNullPointerException, fixTileEntityOnLoadCME, removeForgeSecurityManager, fasterEntitySpawnPreparation;
-    public boolean fixMC30845, fixMC31681, fixMC129057, fixMC129556, resolveMC2071, limitSkinDownloadingThreads;
+    public boolean fixMC30845, fixMC31681, fixMC129057, fixMC129556, resolveMC2071, limitSkinDownloadingThreads, fixMC88176;
     public boolean sparkProfileEntireGameLoad, sparkProfileEntireWorldLoad, sparkProfileCoreModLoading, sparkProfileConstructionStage, sparkProfilePreInitializationStage, sparkProfileInitializationStage, sparkProfilePostInitializationStage, sparkProfileLoadCompleteStage, sparkProfileFinalizingStage, sparkProfileWorldAboutToStartStage, sparkProfileWorldStartingStage, sparkProfileWorldStartedStage, includeAllThreadsWhenProfiling, sparkSummarizeHeapSpaceAfterGameLoads, sparkSummarizeHeapSpaceAfterWorldLoads;
     public boolean furnaceExperienceFCFS, furnaceExperienceVanilla, furnaceExperienceMost;
     public boolean makeEventsSingletons;
@@ -163,6 +163,7 @@ public class LoliConfig {
         fixMC31681 = getBoolean("fixMC31681", "mcfixes", "Fixes MC31681: https://bugs.mojang.com/browse/MC-31681", true);
         fixMC129057 = getBoolean("fixMC129057", "mcfixes", "Fixes MC-129057: https://bugs.mojang.com/browse/MC-129057", true);
         fixMC129556 = getBoolean("fixMC129556", "mcfixes", "Fixes MC-129556: https://bugs.mojang.com/browse/MC-129556", true);
+        fixMC88176 = getBoolean("fixMC88176", "mcfixes", "Fixes MC-88176 (disappearing entities): https://bugs.mojang.com/browse/MC-88176", true);
         resolveMC2071 = getBoolean("resolveMC2071", "mcfixes", "Resolves MC2071: https://bugs.mojang.com/browse/MC-2071", true);
         limitSkinDownloadingThreads = getBoolean("limitSkinDownloadingThreads", "mcfixes", "Limits skin downloading threads to a maximum of half of available CPU cores", true);
 

--- a/src/main/java/zone/rong/loliasm/patches/RenderGlobalPatch.java
+++ b/src/main/java/zone/rong/loliasm/patches/RenderGlobalPatch.java
@@ -1,0 +1,41 @@
+package zone.rong.loliasm.patches;
+
+import net.minecraft.client.renderer.chunk.RenderChunk;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.ClassInheritanceMultiMap;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.world.chunk.Chunk;
+
+@SuppressWarnings("unused")
+public class RenderGlobalPatch {
+    /**
+     * Minecraft is transformed to call this method when it tries to do culling checks. Return a bounding box that
+     * includes all entities, so culling works as it should.
+     */
+    public static AxisAlignedBB getCorrectBoundingBox(RenderChunk renderChunk) {
+        int subChunkYPos = renderChunk.getPosition().getY();
+        Chunk chunk = renderChunk.getWorld().getChunk(renderChunk.getPosition());
+        int subChunkList = subChunkYPos / 16;
+        /* Make sure there is actually going to be an entity list, to be on the safe side */
+        if (subChunkList < 0 || subChunkList >= chunk.getEntityLists().length) {
+            return renderChunk.boundingBox;
+        }
+        ClassInheritanceMultiMap<Entity> entityMap = chunk.getEntityLists()[subChunkList];
+        if (!entityMap.isEmpty()) {
+            /* Use local variables to avoid GC churn during rendering */
+            double minX = renderChunk.boundingBox.minX, minY = renderChunk.boundingBox.minY, minZ = renderChunk.boundingBox.minZ;
+            double maxX = renderChunk.boundingBox.maxX, maxY = renderChunk.boundingBox.maxY, maxZ = renderChunk.boundingBox.maxZ;
+            for (Entity entity : entityMap) {
+                AxisAlignedBB entityBox = entity.getRenderBoundingBox();
+                minX = Math.min(minX, entityBox.minX - 0.5);
+                minY = Math.min(minY, entityBox.minY - 0.5);
+                minZ = Math.min(minZ, entityBox.minZ - 0.5);
+                maxX = Math.max(maxX, entityBox.maxX + 0.5);
+                maxY = Math.max(maxY, entityBox.maxY + 0.5);
+                maxZ = Math.max(maxZ, entityBox.maxZ + 0.5);
+            }
+            return new AxisAlignedBB(minX, minY, minZ, maxX, maxY, maxZ);
+        }
+        return renderChunk.boundingBox;
+    }
+}


### PR DESCRIPTION
- Fix MC-88176 (also compatible with OptiFine)
  - This is an improved version of a fix I previously contributed to Sledgehammer. It now uses ASM and works even when OptiFine is installed. I also rewrote it to use local variables instead of allocating at least two `AxisAlignedBB` objects per entity every time the method is called.
- Make BlockModelRendererMixin work with OptiFine
  - OptiFine's version of this method has a different LVT so I used a redirect instead.