### PR TITLE
Add option to adjust thread priorities

### DIFF
--- a/src/main/java/zone/rong/loliasm/common/priorities/mixins/MinecraftServerMixin.java
+++ b/src/main/java/zone/rong/loliasm/common/priorities/mixins/MinecraftServerMixin.java
@@ -1,0 +1,15 @@
+package zone.rong.loliasm.common.priorities.mixins;
+
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(MinecraftServer.class)
+public class MinecraftServerMixin {
+    @Redirect(method = "startServerThread", at = @At(value = "INVOKE", target = "Ljava/lang/Thread;start()V"))
+    private void setPriorityAndStart(Thread serverThread) {
+        serverThread.setPriority(Thread.MIN_PRIORITY + 2);
+        serverThread.start();
+    }
+}

--- a/src/main/java/zone/rong/loliasm/common/priorities/mixins/client/ChunkRenderDispatcherMixin.java
+++ b/src/main/java/zone/rong/loliasm/common/priorities/mixins/client/ChunkRenderDispatcherMixin.java
@@ -1,0 +1,47 @@
+package zone.rong.loliasm.common.priorities.mixins.client;
+
+import net.minecraft.client.renderer.chunk.ChunkRenderDispatcher;
+import net.minecraft.util.math.MathHelper;
+import org.apache.logging.log4j.Logger;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ChunkRenderDispatcher.class)
+public class ChunkRenderDispatcherMixin {
+    @Shadow @Final @Mutable
+    private int countRenderBuilders;
+
+    @Shadow @Final private static Logger LOGGER;
+
+    private int getRenderBuilderCount() {
+        int processors = Runtime.getRuntime().availableProcessors();
+        boolean allowSingleThread = Runtime.getRuntime().availableProcessors() < 2;
+        return MathHelper.clamp(Math.max(processors / 3, processors - 6), allowSingleThread ? 1 : 2, 10);
+    }
+
+    @ModifyVariable(method = "<init>(I)V", at = @At("STORE"), index = 3, ordinal = 2)
+    private int setBuilders(int original) {
+        return getRenderBuilderCount();
+    }
+
+    @Redirect(method = "<init>(I)V", at = @At(value = "FIELD", opcode = Opcodes.PUTFIELD, target = "Lnet/minecraft/client/renderer/chunk/ChunkRenderDispatcher;countRenderBuilders:I"))
+    private void setBuilders(ChunkRenderDispatcher dispatcher, int original) {
+        int nThreads = getRenderBuilderCount();
+        /* we need more builder objects in the queue than number of threads, because threads don't free them immediately */
+        this.countRenderBuilders = nThreads * 10;
+        LOGGER.info("Creating {} chunk builders", nThreads);
+    }
+
+    @Redirect(method = "<init>(I)V", at = @At(value = "INVOKE", target = "Ljava/lang/Thread;start()V"))
+    private void setPriorityAndStart(Thread workerThread) {
+        workerThread.setPriority(Thread.MIN_PRIORITY + 1);
+        workerThread.start();
+    }
+}

--- a/src/main/java/zone/rong/loliasm/config/LoliConfig.java
+++ b/src/main/java/zone/rong/loliasm/config/LoliConfig.java
@@ -69,7 +69,7 @@ public class LoliConfig {
     public boolean optimizeRegistries, optimizeNBTTagCompoundBackingMap, optimizeFurnaceRecipeStore, stripNearUselessItemStackFields, moreModelManagerCleanup, efficientHashing, replaceSearchTreeWithJEISearching;
     public boolean releaseSpriteFramesCache, onDemandAnimatedTextures;
     public boolean optimizeSomeRendering, stripUnnecessaryLocalsInRenderHelper;
-    public boolean quickerEnableUniversalBucketCheck, stripInstancedRandomFromSoundEventAccessor, classCaching, copyScreenshotToClipboard, releaseScreenshotCache, asyncScreenshot, removeExcessiveGCCalls, smoothDimensionChange;
+    public boolean quickerEnableUniversalBucketCheck, stripInstancedRandomFromSoundEventAccessor, classCaching, copyScreenshotToClipboard, releaseScreenshotCache, asyncScreenshot, removeExcessiveGCCalls, smoothDimensionChange, threadPriorityFix;
     public boolean fixBlockIEBaseArrayIndexOutOfBoundsException, cleanupChickenASMClassHierarchyManager, optimizeAmuletRelatedFunctions, labelCanonicalization, skipCraftTweakerRecalculatingSearchTrees, bwmBlastingOilOptimization, optimizeQMDBeamRenderer, repairEvilCraftEIOCompat, optimizeArcaneLockRendering, fixXU2CrafterCrash, disableXU2CrafterRendering, fixTFCFallingBlockFalseStartingTEPos;
     public boolean fixAmuletHolderCapability, delayItemStackCapabilityInit;
     public boolean fixFillBucketEventNullPointerException, fixTileEntityOnLoadCME, removeForgeSecurityManager, fasterEntitySpawnPreparation, fixDimensionTypesInliningCrash;
@@ -137,6 +137,7 @@ public class LoliConfig {
         asyncScreenshot = getBoolean("asyncScreenshot", "misc", "Process screenshots and print to chat asynchronously", true);
         removeExcessiveGCCalls = getBoolean("removeExcessiveGCCalls", "misc", "Removes forced garbage collection calls, inspired by VanillaFix, can make world loading faster", true);
         smoothDimensionChange = getBoolean("smoothDimensionChange", "misc", "Allows changing of dimensions to be smooth and nearly instantaneous, inspired by VanillaFix", true);
+        threadPriorityFix = getBoolean("threadPriorityFix", "misc", "Adjust thread priorities to improve performance on systems with few cores", true);
 
         fixBlockIEBaseArrayIndexOutOfBoundsException = getBoolean("fixBlockIEBaseArrayIndexOutOfBoundsException", "modfixes", "When Immersive Engineering is installed, sometimes it or it's addons can induce an ArrayIndexOutOfBoundsException in BlockIEBase#getPushReaction. This option will be ignored when IE isn't installed", true);
         cleanupChickenASMClassHierarchyManager = getBoolean("cleanupChickenASMClassHierarchyManager", "modfixes", "EXPERIMENTAL: When ChickenASM (Library of CodeChickenLib and co.) is installed, ClassHierarchyManager can cache a lot of Strings and seem to be unused in any transformation purposes. This clears ClassHierarchyManager of those redundant strings. This option will be ignored when ChickenASM isn't installed", true);

--- a/src/main/java/zone/rong/loliasm/core/LoliLoadingPlugin.java
+++ b/src/main/java/zone/rong/loliasm/core/LoliLoadingPlugin.java
@@ -158,6 +158,7 @@ public class LoliLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader {
                 "mixins.crashes.json",
                 "mixins.fix_mc129057.json",
                 "mixins.bucket.json",
+                "mixins.priorities.json",
                 "mixins.rendering.json",
                 "mixins.datastructures_modelmanager.json",
                 "mixins.screenshot.json",
@@ -179,6 +180,7 @@ public class LoliLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader {
                         "mixins.capability.json",
                         "mixins.singletonevents.json",
                         "mixins.efficienthashing.json",
+                        "mixins.priorities.json",
                         "mixins.crashes.json",
                         "mixins.fix_mc129057.json");
     }

--- a/src/main/java/zone/rong/loliasm/proxy/CommonProxy.java
+++ b/src/main/java/zone/rong/loliasm/proxy/CommonProxy.java
@@ -56,6 +56,8 @@ public class CommonProxy {
         if (LoliConfig.instance.cleanupLaunchClassLoaderEarly) {
             cleanupLaunchClassLoader();
         }
+        if (LoliConfig.instance.threadPriorityFix)
+            Thread.currentThread().setPriority(Thread.NORM_PRIORITY + 2);
     }
 
     public void preInit(FMLPreInitializationEvent event) { }

--- a/src/main/resources/mixins.priorities.json
+++ b/src/main/resources/mixins.priorities.json
@@ -1,0 +1,17 @@
+{
+  "package": "zone.rong.loliasm.common.priorities.mixins",
+  "plugin": "zone.rong.loliasm.core.LoliMixinPlugin",
+  "refmap": "mixins.loliasm.refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "MinecraftServerMixin"
+  ],
+  "client": [
+    "client.ChunkRenderDispatcherMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
To improve Minecraft client performance on systems with very few hardware cores, it's important to keep the concurrently running thread count low, and also ensure the client thread has highest priority (to avoid stutter). To accomplish this, the following priority changes are made if `threadPriorityFix` is enabled:
* Client thread given default priority + 2
* Server thread given min priority + 2
* Chunk builder threads given min priority + 1
* Number of chunk builders adjusted to match Sodium defaults on modern versions. On my i3-4150 (with 2c4t) vanilla creates 4 chunk builders by default, which causes huge amounts of stuttering. With these changes it only creates 1, which makes sense, as that brings the total vanilla thread count to 3 not counting whatever mods do in the background.