### PR TITLE
Revamp releaseSpriteFramesCache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,8 +95,8 @@ dependencies {
     compileOnly 'codechicken:ChickenASM:1.12-1.0.2.9'
     compileOnly 'epicsquid.mysticallib:mysticallib:1.12.2-+'
     compileOnly 'mezz.jei:jei_1.12.2:4.15.0.293'
-    compileOnly 'slimeknights.mantle:Mantle:1.12-1.3.3.55+'
-    compileOnly 'slimeknights:TConstruct:1.12.2-2.13.0.183+'
+    compileOnly 'slimeknights.mantle:Mantle:1.12-1.3.3.55'
+    compileOnly 'slimeknights:TConstruct:1.12.2-2.13.0.183'
     compileOnly 'betterwithmods:BetterWithMods:1.12-2.3.20-1030'
 
     compileOnly rfg.deobf('codechicken:CodeChickenLib:1.12.2-3.2.3.358:universal')

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xmx3G
 # Mod Information
 mod_version = 5.8
 maven_group = zone.rong
-archives_base_name = LoliASM
+archives_base_name = loliasm

--- a/src/main/java/zone/rong/loliasm/client/sprite/FramesTextureData.java
+++ b/src/main/java/zone/rong/loliasm/client/sprite/FramesTextureData.java
@@ -13,10 +13,8 @@ import net.minecraftforge.client.resource.VanillaResourceType;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import zone.rong.loliasm.LoliLogger;
-import zone.rong.loliasm.LoliReflector;
 import zone.rong.loliasm.common.internal.mixins.TextureAtlasSpriteAccessor;
 import zone.rong.loliasm.common.internal.mixins.TextureMapAccessor;
-import zone.rong.loliasm.proxy.ClientProxy;
 
 import java.io.IOException;
 import java.util.*;
@@ -44,7 +42,7 @@ public class FramesTextureData extends ArrayList<int[][]> {
                 canReload = false;
                 Set<Class<?>> skippedSpriteClasses = new HashSet<>();
                 try {
-                    for (TextureAtlasSprite sprite : ((Map<String, TextureAtlasSprite>) LoliReflector.resolveFieldGetter(TextureMap.class, "mapRegisteredSprites", "field_110574_e").invoke(Minecraft.getMinecraft().getTextureMapBlocks())).values()) {
+                    for (TextureAtlasSprite sprite : ((TextureMapAccessor)Minecraft.getMinecraft().getTextureMapBlocks()).getMapRegisteredSprites().values()) {
                         if (sprite.getClass() == TextureAtlasSprite.class || sprite.getClass() == FOAMFIX_SPRITE) {
                             sprite.setFramesTextureData(new FramesTextureData(sprite));
                         } else
@@ -62,7 +60,7 @@ public class FramesTextureData extends ArrayList<int[][]> {
     @SubscribeEvent
     public static void onClientTick(TickEvent.ClientTickEvent event) {
         if (event.phase == TickEvent.Phase.END) {
-            for(TextureAtlasSprite sprite : ((TextureMapAccessor)Minecraft.getMinecraft().getTextureMapBlocks()).getMapUploadedSprites().values()) {
+            for(TextureAtlasSprite sprite : ((TextureMapAccessor)Minecraft.getMinecraft().getTextureMapBlocks()).getMapRegisteredSprites().values()) {
                 if (sprite != null) {
                     List<int[][]> data = ((TextureAtlasSpriteAccessor)sprite).loli$getTextureData();
                     if(data instanceof FramesTextureData)

--- a/src/main/java/zone/rong/loliasm/client/sprite/FramesTextureData.java
+++ b/src/main/java/zone/rong/loliasm/client/sprite/FramesTextureData.java
@@ -91,35 +91,43 @@ public class FramesTextureData extends ArrayList<int[][]> {
 
     @Override
     public int[][] get(int index) {
-        if (canReload && super.isEmpty()) {
-            load();
+        synchronized (this) {
+            if (canReload && super.isEmpty()) {
+                load();
+            }
+            this.ticksInactive = 0;
+            return super.get(index);
         }
-        this.ticksInactive = 0;
-        return super.get(index);
     }
 
     @Override
     public int size() {
-        if (canReload && super.isEmpty()) {
-            load();
+        synchronized (this) {
+            if (canReload && super.isEmpty()) {
+                load();
+            }
+            this.ticksInactive = 0;
+            return super.size();
         }
-        this.ticksInactive = 0;
-        return super.size();
     }
 
     @Override
     public boolean isEmpty() {
-        if (canReload && super.isEmpty()) {
-            load();
+        synchronized (this) {
+            if (canReload && super.isEmpty()) {
+                load();
+            }
+            this.ticksInactive = 0;
+            return super.isEmpty();
         }
-        this.ticksInactive = 0;
-        return super.isEmpty();
     }
 
     @Override
     public void clear() {
-        super.clear();
-        trimToSize();
+        synchronized (this) {
+            super.clear();
+            trimToSize();
+        }
     }
 
     private void load() {

--- a/src/main/java/zone/rong/loliasm/client/sprite/FramesTextureData.java
+++ b/src/main/java/zone/rong/loliasm/client/sprite/FramesTextureData.java
@@ -51,7 +51,7 @@ public class FramesTextureData extends ArrayList<int[][]> {
                 } catch (Throwable e) {
                     e.printStackTrace();
                 }
-                LoliLogger.instance.info("Evicted most sprites' frame texture data, skipped classes: [{}]", skippedSpriteClasses.stream().map(Class::getName).collect(Collectors.joining(", ")));
+                LoliLogger.instance.debug("Evicted most sprites' frame texture data, skipped classes: [{}]", skippedSpriteClasses.stream().map(Class::getName).collect(Collectors.joining(", ")));
                 canReload = true;
             }
         });

--- a/src/main/java/zone/rong/loliasm/client/sprite/FramesTextureData.java
+++ b/src/main/java/zone/rong/loliasm/client/sprite/FramesTextureData.java
@@ -3,69 +3,118 @@ package zone.rong.loliasm.client.sprite;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.client.resources.IReloadableResourceManager;
 import net.minecraft.client.resources.IResource;
 import net.minecraft.client.resources.IResourceManager;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.event.ColorHandlerEvent;
+import net.minecraftforge.client.resource.ISelectiveResourceReloadListener;
+import net.minecraftforge.client.resource.VanillaResourceType;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import zone.rong.loliasm.LoliLogger;
+import zone.rong.loliasm.LoliReflector;
+import zone.rong.loliasm.common.internal.mixins.TextureAtlasSpriteAccessor;
+import zone.rong.loliasm.common.internal.mixins.TextureMapAccessor;
 import zone.rong.loliasm.proxy.ClientProxy;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class FramesTextureData extends ArrayList<int[][]> {
+    private static boolean canReload = true;
 
-    private static final Set<TextureAtlasSprite> scheduledToReleaseCache = Collections.newSetFromMap(new WeakHashMap<>());
+    private static final Class<?> FOAMFIX_SPRITE;
+
+    static {
+        Class<?> ffSprite;
+        try {
+            ffSprite = Class.forName("pl.asie.foamfix.client.FastTextureAtlasSprite");
+        } catch(ClassNotFoundException e) {
+            ffSprite = null;
+        }
+        FOAMFIX_SPRITE = ffSprite;
+    }
+
+    @SubscribeEvent
+    public static void registerEvictionListener(ColorHandlerEvent.Block event) {
+        ((IReloadableResourceManager) Minecraft.getMinecraft().getResourceManager()).registerReloadListener((ISelectiveResourceReloadListener) (manager, predicate) -> {
+            if (predicate.test(VanillaResourceType.MODELS)) {
+                canReload = false;
+                Set<Class<?>> skippedSpriteClasses = new HashSet<>();
+                try {
+                    for (TextureAtlasSprite sprite : ((Map<String, TextureAtlasSprite>) LoliReflector.resolveFieldGetter(TextureMap.class, "mapRegisteredSprites", "field_110574_e").invoke(Minecraft.getMinecraft().getTextureMapBlocks())).values()) {
+                        if (sprite.getClass() == TextureAtlasSprite.class || sprite.getClass() == FOAMFIX_SPRITE) {
+                            sprite.setFramesTextureData(new FramesTextureData(sprite));
+                        } else
+                            skippedSpriteClasses.add(sprite.getClass());
+                    }
+                } catch (Throwable e) {
+                    e.printStackTrace();
+                }
+                LoliLogger.instance.info("Evicted most sprites' frame texture data, skipped classes: [{}]", skippedSpriteClasses.stream().map(Class::getName).collect(Collectors.joining(", ")));
+                canReload = true;
+            }
+        });
+    }
 
     @SubscribeEvent
     public static void onClientTick(TickEvent.ClientTickEvent event) {
-        if (event.phase == TickEvent.Phase.END && !FramesTextureData.scheduledToReleaseCache.isEmpty()) {
-            for (Iterator<TextureAtlasSprite> iter = scheduledToReleaseCache.iterator(); iter.hasNext();) {
-                TextureAtlasSprite sprite = iter.next();
+        if (event.phase == TickEvent.Phase.END) {
+            for(TextureAtlasSprite sprite : ((TextureMapAccessor)Minecraft.getMinecraft().getTextureMapBlocks()).getMapUploadedSprites().values()) {
                 if (sprite != null) {
-                    try {
-                        sprite.clearFramesTextureData();
-                    } catch (NullPointerException e) {
-                        LoliLogger.instance.error("NullPointerException: Trying to clear {}'s FramesTextureData but unable to!", sprite.getIconName());
-                    }
+                    List<int[][]> data = ((TextureAtlasSpriteAccessor)sprite).loli$getTextureData();
+                    if(data instanceof FramesTextureData)
+                        ((FramesTextureData)data).tick();
                 }
-                iter.remove();
             }
         }
     }
 
     private final TextureAtlasSprite sprite;
 
+    private int ticksInactive;
+
+    private static final int INACTIVITY_THRESHOLD = 20;
+
     public FramesTextureData(TextureAtlasSprite sprite) {
         super();
         this.sprite = sprite;
+        this.ticksInactive = INACTIVITY_THRESHOLD + 1;
+    }
+
+    public void tick() {
+        this.ticksInactive++;
+        if(this.ticksInactive == INACTIVITY_THRESHOLD) {
+            this.clear();
+        }
     }
 
     @Override
     public int[][] get(int index) {
-        if (ClientProxy.canReload && super.isEmpty()) {
+        if (canReload && super.isEmpty()) {
             load();
-            Minecraft.getMinecraft().addScheduledTask(() -> scheduledToReleaseCache.add(sprite));
         }
+        this.ticksInactive = 0;
         return super.get(index);
     }
 
     @Override
     public int size() {
-        if (ClientProxy.canReload && super.isEmpty()) {
+        if (canReload && super.isEmpty()) {
             load();
-            Minecraft.getMinecraft().addScheduledTask(() -> scheduledToReleaseCache.add(sprite));
         }
+        this.ticksInactive = 0;
         return super.size();
     }
 
     @Override
     public boolean isEmpty() {
-        if (ClientProxy.canReload && super.isEmpty()) {
+        if (canReload && super.isEmpty()) {
             load();
-            Minecraft.getMinecraft().addScheduledTask(() -> scheduledToReleaseCache.add(sprite));
         }
+        this.ticksInactive = 0;
         return super.isEmpty();
     }
 
@@ -76,17 +125,24 @@ public class FramesTextureData extends ArrayList<int[][]> {
     }
 
     private void load() {
-        ResourceLocation location = getLocation();
-        IResourceManager resourceManager = Minecraft.getMinecraft().getResourceManager();
-        TextureMap textureMap = Minecraft.getMinecraft().getTextureMapBlocks();
-        if (sprite.hasCustomLoader(resourceManager, location)) {
-            sprite.load(resourceManager, location, rl -> textureMap.getAtlasSprite(rl.toString()));
-        } else {
-            try (IResource resource = resourceManager.getResource(location)) {
-                sprite.loadSpriteFrames(resource, 1);
-            } catch (IOException e) {
-                e.printStackTrace();
+        // prevent recursive loads
+        boolean oldReload = canReload;
+        canReload = false;
+        try {
+            ResourceLocation location = getLocation();
+            IResourceManager resourceManager = Minecraft.getMinecraft().getResourceManager();
+            TextureMap textureMap = Minecraft.getMinecraft().getTextureMapBlocks();
+            if (sprite.hasCustomLoader(resourceManager, location)) {
+                sprite.load(resourceManager, location, rl -> textureMap.getAtlasSprite(rl.toString()));
+            } else {
+                try (IResource resource = resourceManager.getResource(location)) {
+                    sprite.loadSpriteFrames(resource, 1);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
             }
+        } finally {
+            canReload = oldReload;
         }
     }
 

--- a/src/main/java/zone/rong/loliasm/common/internal/mixins/TextureAtlasSpriteAccessor.java
+++ b/src/main/java/zone/rong/loliasm/common/internal/mixins/TextureAtlasSpriteAccessor.java
@@ -1,4 +1,13 @@
 package zone.rong.loliasm.common.internal.mixins;
 
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.List;
+
+@Mixin(TextureAtlasSprite.class)
 public interface TextureAtlasSpriteAccessor {
+    @Accessor("framesTextureData")
+    List<int[][]> loli$getTextureData();
 }

--- a/src/main/java/zone/rong/loliasm/common/internal/mixins/TextureAtlasSpriteAccessor.java
+++ b/src/main/java/zone/rong/loliasm/common/internal/mixins/TextureAtlasSpriteAccessor.java
@@ -1,0 +1,4 @@
+package zone.rong.loliasm.common.internal.mixins;
+
+public interface TextureAtlasSpriteAccessor {
+}

--- a/src/main/java/zone/rong/loliasm/common/internal/mixins/TextureMapAccessor.java
+++ b/src/main/java/zone/rong/loliasm/common/internal/mixins/TextureMapAccessor.java
@@ -1,2 +1,14 @@
-package zone.rong.loliasm.common.internal.mixins;public interface TextureMapAccessor {
+package zone.rong.loliasm.common.internal.mixins;
+
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.renderer.texture.TextureMap;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Map;
+
+@Mixin(TextureMap.class)
+public interface TextureMapAccessor {
+    @Accessor("mapUploadedSprites")
+    Map<String, TextureAtlasSprite> getMapUploadedSprites();
 }

--- a/src/main/java/zone/rong/loliasm/common/internal/mixins/TextureMapAccessor.java
+++ b/src/main/java/zone/rong/loliasm/common/internal/mixins/TextureMapAccessor.java
@@ -9,6 +9,6 @@ import java.util.Map;
 
 @Mixin(TextureMap.class)
 public interface TextureMapAccessor {
-    @Accessor("mapUploadedSprites")
-    Map<String, TextureAtlasSprite> getMapUploadedSprites();
+    @Accessor("mapRegisteredSprites")
+    Map<String, TextureAtlasSprite> getMapRegisteredSprites();
 }

--- a/src/main/java/zone/rong/loliasm/common/internal/mixins/TextureMapAccessor.java
+++ b/src/main/java/zone/rong/loliasm/common/internal/mixins/TextureMapAccessor.java
@@ -1,0 +1,2 @@
+package zone.rong.loliasm.common.internal.mixins;public interface TextureMapAccessor {
+}

--- a/src/main/java/zone/rong/loliasm/proxy/ClientProxy.java
+++ b/src/main/java/zone/rong/loliasm/proxy/ClientProxy.java
@@ -1,8 +1,6 @@
 package zone.rong.loliasm.proxy;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.texture.TextureAtlasSprite;
-import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.resources.IReloadableResourceManager;
 import net.minecraftforge.client.resource.ISelectiveResourceReloadListener;
 import net.minecraftforge.client.resource.VanillaResourceType;
@@ -13,8 +11,6 @@ import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLLoadCompleteEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.relauncher.Side;
-import pl.asie.foamfix.shared.FoamFixShared;
-import slimeknights.tconstruct.library.client.texture.AbstractColoredTexture;
 import zone.rong.loliasm.LoliLogger;
 import zone.rong.loliasm.LoliReflector;
 import zone.rong.loliasm.bakedquad.LoliVertexDataPool;
@@ -33,19 +29,6 @@ import java.util.Map;
 public class ClientProxy extends CommonProxy {
 
     public static final List<Runnable> refreshAfterModels = new ArrayList<>();
-    public static final boolean flushTinkerSpriteFrameTextureData;
-
-    static {
-        boolean static$flushTinkerSpriteFrameTextureData = true;
-        if (Loader.isModLoaded("tconstruct") && Loader.isModLoaded("foamfix")) {
-            if (FoamFixShared.config.clDynamicItemModels) {
-                static$flushTinkerSpriteFrameTextureData = false;
-            }
-        }
-        flushTinkerSpriteFrameTextureData = static$flushTinkerSpriteFrameTextureData;
-    }
-
-    public static boolean canReload = true;
 
     @Override
     public void preInit(FMLPreInitializationEvent event) {
@@ -90,22 +73,6 @@ public class ClientProxy extends CommonProxy {
                     LoliBakedDynBucket.flippedBaseQuads.clear();
                     LoliBakedDynBucket.coverQuads.clear();
                     LoliBakedDynBucket.flippedCoverQuads.clear();
-                }
-                if (LoliConfig.instance.releaseSpriteFramesCache) {
-                    canReload = false;
-                    try {
-                        for (TextureAtlasSprite sprite : ((Map<String, TextureAtlasSprite>) LoliReflector.resolveFieldGetter(TextureMap.class, "mapRegisteredSprites", "field_110574_e").invoke(Minecraft.getMinecraft().getTextureMapBlocks())).values()) {
-                            if (!sprite.hasAnimationMetadata()) {
-                                if (!flushTinkerSpriteFrameTextureData && sprite instanceof AbstractColoredTexture) {
-                                    continue;
-                                }
-                                sprite.setFramesTextureData(new FramesTextureData(sprite));
-                            }
-                        }
-                    } catch (Throwable e) {
-                        e.printStackTrace();
-                    }
-                    canReload = true;
                 }
                 if (!LoliTransformer.isOptifineInstalled && LoliConfig.instance.vertexDataCanonicalization) {
                     LoliVertexDataPool.invalidate();

--- a/src/main/resources/mixins.internal.json
+++ b/src/main/resources/mixins.internal.json
@@ -10,6 +10,8 @@
     "LoadControllerMixin"
   ],
   "client": [
+    "TextureAtlasSpriteAccessor",
+    "TextureMapAccessor",
     "TextureManagerAccessor",
     "TileEntityMixin"
   ]


### PR DESCRIPTION
This optimization now applies only to `TextureAtlasSprite` (and FoamFix's copy of the class). Data is now unloaded for all sprites (including animated ones) at startup and is reloaded as needed. Once it has been reloaded, it will remain loaded until it has not been referenced for 20 client ticks, after which it unloads again.

The idea is to take advantage of `onDemandAnimatedTextures` and not need to keep animated texture data in memory either except for visible animated textures. This can save at least 80MB of memory in larger packs.

This implementation also requires no special casing to work correctly with Tinkers Construct and FoamFix, as it specifically targets the vanilla texture sprite class only (for maximum compatibility).

Would appreciate if someone could give this a go in a larger pack as I have only done testing with a couple mods.