### PR TITLE
Fix Thermal Expansion machine item texture bug

### DIFF
--- a/src/main/java/zone/rong/loliasm/bakedquad/SupportingBakedQuad.java
+++ b/src/main/java/zone/rong/loliasm/bakedquad/SupportingBakedQuad.java
@@ -33,7 +33,7 @@ public class SupportingBakedQuad extends BakedQuad {
 
     @Override
     public EnumFacing getFace() {
-        return face;
+        return face != null ? face : EnumFacing.DOWN;
     }
 
     @Override


### PR DESCRIPTION
A weird bug that happens because of face being null. Returning down or any other facing doesn't change the rendering. So i guess that's a fix?