### PR TITLE
Fix `player.setInvulnerable(true);` not working

### DIFF
--- a/src/main/java/zone/rong/loliasm/vanillafix/bugfixes/mixins/MixinEntityPlayerMP.java
+++ b/src/main/java/zone/rong/loliasm/vanillafix/bugfixes/mixins/MixinEntityPlayerMP.java
@@ -12,8 +12,8 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import zone.rong.mixinextras.injector.ModifyReturnValue;
 
 @Mixin(EntityPlayerMP.class)
 public abstract class MixinEntityPlayerMP extends EntityPlayer {
@@ -27,8 +27,8 @@ public abstract class MixinEntityPlayerMP extends EntityPlayer {
      * teleporting the player again (in the other nether portal before the client had the
      * time to confirm the teleport).
      */
-    @Redirect(method = "isEntityInvulnerable", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;isEntityInvulnerable(Lnet/minecraft/util/DamageSource;)Z"))
-    private boolean isEntityInvulnerable(EntityPlayer entityPlayer, DamageSource source) {
+    @ModifyReturnValue(method = "isEntityInvulnerable", at = @At(value = "RETURN"))
+    private boolean isEntityInvulnerable(boolean original, DamageSource source) {
         return super.isEntityInvulnerable(source);
     }
 

--- a/src/main/java/zone/rong/loliasm/vanillafix/bugfixes/mixins/MixinEntityPlayerMP.java
+++ b/src/main/java/zone/rong/loliasm/vanillafix/bugfixes/mixins/MixinEntityPlayerMP.java
@@ -29,7 +29,7 @@ public abstract class MixinEntityPlayerMP extends EntityPlayer {
      */
     @Redirect(method = "isEntityInvulnerable", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;isEntityInvulnerable(Lnet/minecraft/util/DamageSource;)Z"))
     private boolean isEntityInvulnerable(EntityPlayer entityPlayer, DamageSource source) {
-        return false;
+        return super.isEntityInvulnerable(source);
     }
 
     /**


### PR DESCRIPTION
The original intent for this Mixin was to remove `this.isInvulnerableDimensionChange()` because it could be abused.
But returning false breaks `player.setInvulnerable(true)` this should still prevent players from abusing dimension changing while allowing mods and plugins to set an entity invulnerable.