### PR TITLE
Config "threadPriorityFix" now disables mixin as well

### DIFF
--- a/src/main/java/zone/rong/loliasm/core/LoliLoadingPlugin.java
+++ b/src/main/java/zone/rong/loliasm/core/LoliLoadingPlugin.java
@@ -245,6 +245,8 @@ public class LoliLoadingPlugin implements IFMLLoadingPlugin, IEarlyMixinLoader {
                 return LoliConfig.instance.crashReportImprovements;
             case "mixins.fix_mc129057.json":
                 return LoliConfig.instance.fixMC129057;
+            case "mixins.priorities.json":
+                return LoliConfig.instance.threadPriorityFix;
         }
         return true;
     }


### PR DESCRIPTION
Setting threadPriorityFix to false now disables mixin as well. This fixes the crash related to #194 and restores SpongeForge compatibility.