### PR TITLE
Account for a null TextureAtlasSprite like with SGCraft

### DIFF
--- a/src/main/java/zone/rong/loliasm/client/sprite/ondemand/mixins/VertexLighterFlatMixin.java
+++ b/src/main/java/zone/rong/loliasm/client/sprite/ondemand/mixins/VertexLighterFlatMixin.java
@@ -10,6 +10,8 @@ import zone.rong.loliasm.client.sprite.ondemand.IAnimatedSpritePrimer;
 import zone.rong.loliasm.client.sprite.ondemand.ICompiledChunkExpander;
 import zone.rong.loliasm.client.sprite.ondemand.IVertexLighterExpander;
 
+import java.util.Objects;
+
 @Mixin(VertexLighterFlat.class)
 public abstract class VertexLighterFlatMixin extends QuadGatheringTransformer implements IVertexLighterExpander {
 
@@ -23,7 +25,7 @@ public abstract class VertexLighterFlatMixin extends QuadGatheringTransformer im
 
     @Override
     public void setTexture(TextureAtlasSprite texture) {
-        if (this.primedForDispatch && texture.hasAnimationMetadata()) {
+        if (this.primedForDispatch && Objects.nonNull(texture) && texture.hasAnimationMetadata()) {
             CompiledChunk chunk = IAnimatedSpritePrimer.CURRENT_COMPILED_CHUNK.get();
             if (chunk != null) {
                 ((ICompiledChunkExpander) chunk).resolve(texture);


### PR DESCRIPTION
SGcraft passes a null TextureAtlasSprite through its renderer so only a simple null check is needed to fix #137