### PR TITLE
fix optimizeNBTTagCompoundBackingMap option

### DIFF
--- a/src/main/java/zone/rong/loliasm/api/datastructures/TagMap.java
+++ b/src/main/java/zone/rong/loliasm/api/datastructures/TagMap.java
@@ -66,12 +66,17 @@ public class TagMap<K, V> implements Map<K, V> {
 
     @Override
     public void putAll(Map<? extends K, ? extends V> m) {
-        this.map.putAll(m);
+        m.forEach(this::put);
     }
 
     @Override
     public void clear() {
-        this.map.clear();
+        if (this.threshold != -1) {
+            if (this.map instanceof AutoCanonizingHashMap) this.map = new AutoCanonizingArrayMap<>();
+            else if (this.map instanceof Object2ObjectOpenHashMap) this.map = new Object2ObjectArrayMap<>();
+            else this.map.clear();
+        }
+        else this.map.clear();
     }
 
     @Nonnull

--- a/src/main/java/zone/rong/loliasm/api/datastructures/TagMap.java
+++ b/src/main/java/zone/rong/loliasm/api/datastructures/TagMap.java
@@ -1,0 +1,93 @@
+package zone.rong.loliasm.api.datastructures;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import zone.rong.loliasm.api.datastructures.canonical.AutoCanonizingArrayMap;
+import zone.rong.loliasm.api.datastructures.canonical.AutoCanonizingHashMap;
+import zone.rong.loliasm.config.LoliConfig;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+public class TagMap<K, V> implements Map<K, V> {
+
+    private Map<K, V> map;
+    private final int threshold;
+
+    public TagMap() {
+        this(LoliConfig.instance.optimizeNBTTagCompoundMapThreshold, LoliConfig.instance.nbtBackingMapStringCanonicalization, LoliConfig.instance.optimizeNBTTagCompoundBackingMap);
+    }
+
+    public TagMap(int threshold, boolean canonicalizeString, boolean optimizeMap) {
+        this.threshold = optimizeMap ? threshold : -1;
+        if (canonicalizeString) this.map = optimizeMap ? new AutoCanonizingArrayMap<>() : new AutoCanonizingHashMap<>();
+        else this.map = optimizeMap ? new Object2ObjectArrayMap<>() : new Object2ObjectOpenHashMap<>();
+    }
+
+    @Override
+    public int size() {
+        return this.map.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.map.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return this.map.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return this.map.containsValue(value);
+    }
+
+    @Override
+    public V get(Object key) {
+        return this.map.get(key);
+    }
+
+    @Override
+    public V put(K key, V value) {
+        if (this.size() == this.threshold) {
+            this.map = this.map instanceof AutoCanonizingArrayMap ? new AutoCanonizingHashMap<>(this.map) : new Object2ObjectOpenHashMap<>(this.map);
+        }
+        return this.map.put(key, value);
+    }
+
+    @Override
+    public V remove(Object key) {
+        return this.map.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        this.map.putAll(m);
+    }
+
+    @Override
+    public void clear() {
+        this.map.clear();
+    }
+
+    @Nonnull
+    @Override
+    public Set<K> keySet() {
+        return this.map.keySet();
+    }
+
+    @Nonnull
+    @Override
+    public Collection<V> values() {
+        return this.map.values();
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return this.map.entrySet();
+    }
+}

--- a/src/main/java/zone/rong/loliasm/api/datastructures/canonical/AutoCanonizingHashMap.java
+++ b/src/main/java/zone/rong/loliasm/api/datastructures/canonical/AutoCanonizingHashMap.java
@@ -1,0 +1,28 @@
+package zone.rong.loliasm.api.datastructures.canonical;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import zone.rong.loliasm.api.LoliStringPool;
+
+import java.util.Map;
+
+public class AutoCanonizingHashMap<K, V> extends Object2ObjectOpenHashMap<K, V> {
+
+    public AutoCanonizingHashMap() {
+        super();
+    }
+
+    public AutoCanonizingHashMap(Map<K, V> map) {
+        super(map);
+    }
+
+    @Override
+    public V put(K k, V v) {
+        if (k instanceof String) {
+            k = (K) LoliStringPool.canonicalize((String) k);
+        }
+        if (v instanceof String) {
+            v = (V) LoliStringPool.canonicalize((String) v);
+        }
+        return super.put(k, v);
+    }
+}

--- a/src/main/java/zone/rong/loliasm/config/LoliConfig.java
+++ b/src/main/java/zone/rong/loliasm/config/LoliConfig.java
@@ -67,6 +67,7 @@ public class LoliConfig {
     public boolean resourceLocationCanonicalization, modelConditionCanonicalization, nbtTagStringBackingStringCanonicalization, nbtBackingMapStringCanonicalization, packageStringCanonicalization, lockCodeCanonicalization, spriteNameCanonicalization, asmDataStringCanonicalization, vertexDataCanonicalization, filePermissionsCacheCanonicalization;
     public boolean optimizeFMLRemapper;
     public boolean optimizeRegistries, optimizeNBTTagCompoundBackingMap, optimizeFurnaceRecipeStore, stripNearUselessItemStackFields, moreModelManagerCleanup, efficientHashing, replaceSearchTreeWithJEISearching;
+    public int optimizeNBTTagCompoundMapThreshold;
     public boolean releaseSpriteFramesCache, onDemandAnimatedTextures;
     public boolean optimizeSomeRendering, stripUnnecessaryLocalsInRenderHelper;
     public boolean quickerEnableUniversalBucketCheck, stripInstancedRandomFromSoundEventAccessor, classCaching, copyScreenshotToClipboard, releaseScreenshotCache, asyncScreenshot, removeExcessiveGCCalls, smoothDimensionChange, threadPriorityFix, outdatedCaCertsFix;
@@ -117,6 +118,7 @@ public class LoliConfig {
         // optimizeDataStructures = getBoolean("optimizeDataStructures", "datastructures", "Optimizes various data structures around Minecraft", true);
         optimizeRegistries = getBoolean("optimizeRegistries", "datastructures", "Optimizes registries", true);
         optimizeNBTTagCompoundBackingMap = getBoolean("optimizeNBTTagCompoundBackingMap", "datastructures", "Optimize NBTTagCompound's backing map structure", true);
+        optimizeNBTTagCompoundMapThreshold = getInteger("optimizeNBTTagCompoundMapThreshold", "datastructures", "Max size NBTTagCompounds backing map can get before it gets changed to HashMap from ArrayMap", 8);
         optimizeFurnaceRecipeStore = getBoolean("optimizeFurnaceRecipeStore", "datastructures", "Optimizing FurnaceRecipes. FastFurnace will see very little benefit when this option is turned on", true);
         stripNearUselessItemStackFields = getBoolean("stripNearUselessItemStackFields", "datastructures", "EXPERIMENTAL: Strips ItemStack of some of its fields as it stores some near-useless references", true);
         moreModelManagerCleanup = getBoolean("moreModelManagerCleanup", "datastructures", "Clears and trims ModelManager data structures after models are loaded and baked", true);
@@ -241,6 +243,16 @@ public class LoliConfig {
         prop.setShowInGui(true);
         prop.setLanguageKey("loliasm.config." + name);
         return prop.getBoolean(defaultValue);
+    }
+
+    private int getInteger(String name, String category, String description, int defaultValue) {
+        Property prop = configuration.get(category, name, defaultValue);
+        prop.setDefaultValue(defaultValue);
+        prop.setComment(description + " - <default: " + defaultValue + ">");
+        prop.setRequiresMcRestart(true);
+        prop.setShowInGui(true);
+        prop.setLanguageKey("loliasm.config." + name);
+        return prop.getInt(defaultValue);
     }
 
     private String[] getStringArray(String name, String category, String description, String... defaultValue) {

--- a/src/main/java/zone/rong/loliasm/config/LoliConfig.java
+++ b/src/main/java/zone/rong/loliasm/config/LoliConfig.java
@@ -118,7 +118,7 @@ public class LoliConfig {
         // optimizeDataStructures = getBoolean("optimizeDataStructures", "datastructures", "Optimizes various data structures around Minecraft", true);
         optimizeRegistries = getBoolean("optimizeRegistries", "datastructures", "Optimizes registries", true);
         optimizeNBTTagCompoundBackingMap = getBoolean("optimizeNBTTagCompoundBackingMap", "datastructures", "Optimize NBTTagCompound's backing map structure", true);
-        optimizeNBTTagCompoundMapThreshold = getInteger("optimizeNBTTagCompoundMapThreshold", "datastructures", "Max size NBTTagCompounds backing map can get before it gets changed to HashMap from ArrayMap", 8);
+        optimizeNBTTagCompoundMapThreshold = getInteger("optimizeNBTTagCompoundMapThreshold", "datastructures", "Max size NBTTagCompounds backing map can get before it gets changed to HashMap from ArrayMap", 5);
         optimizeFurnaceRecipeStore = getBoolean("optimizeFurnaceRecipeStore", "datastructures", "Optimizing FurnaceRecipes. FastFurnace will see very little benefit when this option is turned on", true);
         stripNearUselessItemStackFields = getBoolean("stripNearUselessItemStackFields", "datastructures", "EXPERIMENTAL: Strips ItemStack of some of its fields as it stores some near-useless references", true);
         moreModelManagerCleanup = getBoolean("moreModelManagerCleanup", "datastructures", "Clears and trims ModelManager data structures after models are loaded and baked", true);

--- a/src/main/java/zone/rong/loliasm/core/LoliHooks.java
+++ b/src/main/java/zone/rong/loliasm/core/LoliHooks.java
@@ -2,16 +2,13 @@ package zone.rong.loliasm.core;
 
 import it.unimi.dsi.fastutil.objects.*;
 import net.minecraft.client.renderer.block.model.BakedQuad;
-import net.minecraft.nbt.NBTBase;
 import net.minecraftforge.fml.common.discovery.ASMDataTable;
 import net.minecraftforge.fml.common.discovery.ModCandidate;
 import zone.rong.loliasm.api.LoliStringPool;
-import zone.rong.loliasm.api.datastructures.canonical.AutoCanonizingHashMap;
 import zone.rong.loliasm.bakedquad.BakedQuadFactory;
 import zone.rong.loliasm.bakedquad.SupportingBakedQuad;
 import zone.rong.loliasm.config.LoliConfig;
 
-import java.util.Map;
 import java.util.Set;
 
 @SuppressWarnings("unused")
@@ -86,12 +83,5 @@ public class LoliHooks {
 
     public static String nbtTagString$override$ctor(String data) {
         return LoliStringPool.canonicalize(data);
-    }
-
-    public static Map<String, NBTBase> nbtTagCompound$getMap(Map<String, NBTBase> map, int mapThreshold) {
-        if (map.size() == mapThreshold) {
-            return new AutoCanonizingHashMap<>(map);
-        }
-        return map;
     }
 }

--- a/src/main/java/zone/rong/loliasm/core/LoliHooks.java
+++ b/src/main/java/zone/rong/loliasm/core/LoliHooks.java
@@ -2,13 +2,16 @@ package zone.rong.loliasm.core;
 
 import it.unimi.dsi.fastutil.objects.*;
 import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.nbt.NBTBase;
 import net.minecraftforge.fml.common.discovery.ASMDataTable;
 import net.minecraftforge.fml.common.discovery.ModCandidate;
 import zone.rong.loliasm.api.LoliStringPool;
+import zone.rong.loliasm.api.datastructures.canonical.AutoCanonizingHashMap;
 import zone.rong.loliasm.bakedquad.BakedQuadFactory;
 import zone.rong.loliasm.bakedquad.SupportingBakedQuad;
 import zone.rong.loliasm.config.LoliConfig;
 
+import java.util.Map;
 import java.util.Set;
 
 @SuppressWarnings("unused")
@@ -85,4 +88,10 @@ public class LoliHooks {
         return LoliStringPool.canonicalize(data);
     }
 
+    public static Map<String, NBTBase> nbtTagCompound$getMap(Map<String, NBTBase> map, int mapThreshold) {
+        if (map.size() == mapThreshold) {
+            return new AutoCanonizingHashMap<>(map);
+        }
+        return map;
+    }
 }

--- a/src/main/java/zone/rong/loliasm/core/LoliTransformer.java
+++ b/src/main/java/zone/rong/loliasm/core/LoliTransformer.java
@@ -475,93 +475,19 @@ public class LoliTransformer implements IClassTransformer {
         ClassReader reader = new ClassReader(bytes);
         ClassNode node = new ClassNode();
         reader.accept(node, 0);
-        if (optimizeMap && mapThreshold > 0) {
-            for (FieldNode field : node.fields) {
-                if (field.desc.endsWith("/Map;")) {
-                    field.access ^= ACC_FINAL;
-                    break;
-                }
-            }
-        }
-        String map = optimizeMap && mapThreshold > 0 ? (canonicalizeString ? "zone/rong/loliasm/api/datastructures/canonical/AutoCanonizingArrayMap" : "it/unimi/dsi/fastutil/objects/Object2ObjectArrayMap") : "zone/rong/loliasm/api/datastructures/canonical/AutoCanonizingHashMap";
         for (MethodNode method : node.methods) {
             if (method.name.equals("<init>")) {
                 ListIterator<AbstractInsnNode> iter = method.instructions.iterator();
                 while (iter.hasNext()) {
                     AbstractInsnNode instruction = iter.next();
                     if (instruction.getOpcode() == INVOKESTATIC) {
-                        iter.set(new TypeInsnNode(NEW, map));
+                        iter.set(new TypeInsnNode(NEW, "zone/rong/loliasm/api/datastructures/TagMap"));
                         iter.add(new InsnNode(DUP));
-                        iter.add(new MethodInsnNode(INVOKESPECIAL, map, "<init>", "()V", false));
+                        iter.add(new MethodInsnNode(INVOKESPECIAL, "zone/rong/loliasm/api/datastructures/TagMap", "<init>", "()V", false));
                         break;
                     }
                 }
-            }
-            else if (optimizeMap && mapThreshold > 0) {
-                if (LoliLoadingPlugin.isDeobf) {
-                    switch (method.name) {
-                        case "setTag":
-                        case "setByte":
-                        case "setShort":
-                        case "setInteger":
-                        case "setLong":
-                        case "setFloat":
-                        case "setDouble":
-                        case "setString":
-                        case "setByteArray":
-                        case "setIntArray": {
-                            Iterator<AbstractInsnNode> iterator = method.instructions.iterator();
-                            while (iterator.hasNext()) {
-                                AbstractInsnNode n = iterator.next();
-                                if (n.getOpcode() == ALOAD && ((VarInsnNode) n).var == 0) {
-                                    InsnList list = new InsnList();
-                                    list.add(new VarInsnNode(ALOAD, 0));
-                                    list.add(new VarInsnNode(ALOAD, 0));
-                                    list.add(new FieldInsnNode(GETFIELD, node.name, "tagMap", "Ljava/util/Map;"));
-                                    list.add(new FieldInsnNode(GETSTATIC, "zone/rong/loliasm/config/LoliConfig", "instance", "Lzone/rong/loliasm/config/LoliConfig;"));
-                                    list.add(new FieldInsnNode(GETFIELD, "zone/rong/loliasm/config/LoliConfig", "optimizeNBTTagCompoundMapThreshold", "I"));
-                                    list.add(new MethodInsnNode(INVOKESTATIC, "zone/rong/loliasm/core/LoliHooks", "nbtTagCompound$getMap", "(Ljava/util/Map;I)Ljava/util/Map;", false));
-                                    list.add(new FieldInsnNode(PUTFIELD, node.name, "tagMap", "Ljava/util/Map;"));
-                                    method.instructions.insertBefore(n, list);
-                                    break;
-                                }
-                            }
-                            break;
-                        }
-                    }
-                }
-                else {
-                    switch (method.name) {
-                        case "func_74782_a":
-                        case "func_74774_a":
-                        case "func_74777_a":
-                        case "func_74768_a":
-                        case "func_74772_a":
-                        case "func_74776_a":
-                        case "func_74780_a":
-                        case "func_74778_a":
-                        case "func_74773_a":
-                        case "func_74783_a": {
-                            Iterator<AbstractInsnNode> iterator = method.instructions.iterator();
-                            while (iterator.hasNext()) {
-                                AbstractInsnNode n = iterator.next();
-                                if (n.getOpcode() == ALOAD && ((VarInsnNode) n).var == 0) {
-                                    InsnList list = new InsnList();
-                                    list.add(new VarInsnNode(ALOAD, 0));
-                                    list.add(new VarInsnNode(ALOAD, 0));
-                                    list.add(new FieldInsnNode(GETFIELD, node.name, "field_74784_a", "Ljava/util/Map;"));
-                                    list.add(new FieldInsnNode(GETSTATIC, "zone/rong/loliasm/config/LoliConfig", "instance", "Lzone/rong/loliasm/config/LoliConfig;"));
-                                    list.add(new FieldInsnNode(GETFIELD, "zone/rong/loliasm/config/LoliConfig", "optimizeNBTTagCompoundMapThreshold", "I"));
-                                    list.add(new MethodInsnNode(INVOKESTATIC, "zone/rong/loliasm/core/LoliHooks", "nbtTagCompound$getMap", "(Ljava/util/Map;I)Ljava/util/Map;", false));
-                                    list.add(new FieldInsnNode(PUTFIELD, node.name, "field_74784_a", "Ljava/util/Map;"));
-                                    method.instructions.insertBefore(n, list);
-                                    break;
-                                }
-                            }
-                            break;
-                        }
-                    }
-                }
+                break;
             }
         }
         ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES);

--- a/src/main/java/zone/rong/loliasm/core/LoliTransformer.java
+++ b/src/main/java/zone/rong/loliasm/core/LoliTransformer.java
@@ -497,7 +497,7 @@ public class LoliTransformer implements IClassTransformer {
                     }
                 }
             }
-            else {
+            else if (optimizeMap && mapThreshold > 0) {
                 if (LoliLoadingPlugin.isDeobf) {
                     switch (method.name) {
                         case "setTag":


### PR DESCRIPTION
Implements the ArrayMap to HashMap conversion based on threshold with support for string canonicalization.
The threshold can be set with changing 'optimizeNBTTagCompoundMapThreshold' option and its default value is 8.