### PR TITLE
Add CraftTweaker compat for NBTTagCompound backing map optimization

### DIFF
--- a/src/main/java/zone/rong/loliasm/common/modfixes/crafttweaker/mixins/NBTConverterMixin.java
+++ b/src/main/java/zone/rong/loliasm/common/modfixes/crafttweaker/mixins/NBTConverterMixin.java
@@ -1,0 +1,22 @@
+package zone.rong.loliasm.common.modfixes.crafttweaker.mixins;
+
+import java.util.Map;
+
+import crafttweaker.api.data.IData;
+import crafttweaker.mc1120.data.NBTConverter;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Slice;
+import zone.rong.loliasm.api.datastructures.LoliTagMap;
+
+@Mixin(value = NBTConverter.class, remap = false)
+public class NBTConverterMixin {
+    @ModifyVariable(method = "from(Lnet/minecraft/nbt/NBTBase;Z)Lcrafttweaker/api/data/IData;",
+            slice = @Slice(from = @At(value = "NEW", target = "()Ljava/util/HashMap;")),
+            at = @At(value = "STORE", opcode = Opcodes.ASTORE), ordinal = 0)
+    private static Map<String, IData> replaceDefaultHashMap(Map<String, IData> original) {
+        return new LoliTagMap<>();
+    }
+}

--- a/src/main/java/zone/rong/loliasm/config/LoliConfig.java
+++ b/src/main/java/zone/rong/loliasm/config/LoliConfig.java
@@ -71,7 +71,7 @@ public class LoliConfig {
     public boolean releaseSpriteFramesCache, onDemandAnimatedTextures;
     public boolean optimizeSomeRendering, stripUnnecessaryLocalsInRenderHelper;
     public boolean quickerEnableUniversalBucketCheck, stripInstancedRandomFromSoundEventAccessor, classCaching, copyScreenshotToClipboard, releaseScreenshotCache, asyncScreenshot, removeExcessiveGCCalls, smoothDimensionChange, threadPriorityFix, outdatedCaCertsFix;
-    public boolean fixBlockIEBaseArrayIndexOutOfBoundsException, cleanupChickenASMClassHierarchyManager, optimizeAmuletRelatedFunctions, labelCanonicalization, skipCraftTweakerRecalculatingSearchTrees, bwmBlastingOilOptimization, optimizeQMDBeamRenderer, repairEvilCraftEIOCompat, optimizeArcaneLockRendering, fixXU2CrafterCrash, disableXU2CrafterRendering, fixTFCFallingBlockFalseStartingTEPos, disableBrokenParticles;
+    public boolean fixBlockIEBaseArrayIndexOutOfBoundsException, cleanupChickenASMClassHierarchyManager, optimizeAmuletRelatedFunctions, labelCanonicalization, skipCraftTweakerRecalculatingSearchTrees, bwmBlastingOilOptimization, optimizeQMDBeamRenderer, repairEvilCraftEIOCompat, optimizeArcaneLockRendering, fixXU2CrafterCrash, disableXU2CrafterRendering, fixTFCFallingBlockFalseStartingTEPos, disableBrokenParticles, optimizeCraftTweakerNBTConverter;
     public boolean fixAmuletHolderCapability, delayItemStackCapabilityInit;
     public boolean fixFillBucketEventNullPointerException, fixTileEntityOnLoadCME, removeForgeSecurityManager, fasterEntitySpawnPreparation, fixDimensionTypesInliningCrash;
     public boolean fixMC30845, fixMC31681, fixMC88176, fixMC129057, fixMC129556, fixMC186052, resolveMC2071, limitSkinDownloadingThreads;
@@ -155,6 +155,7 @@ public class LoliConfig {
         disableXU2CrafterRendering = getBoolean("disableXU2CrafterRendering", "modfixes", "When Extra Utilities 2 is installed, disable the crafter's rendering of the item being crafted, this can reduce lag, ignores fixXU2CrafterCrash config option", false);
         fixTFCFallingBlockFalseStartingTEPos = getBoolean("fixTFCFallingBlockFalseStartingTEPos", "modfixes", "When TerraFirmaCraft is installed, fix the falling block's false starting position ", true);
         disableBrokenParticles = getBoolean("disableBrokenParticles", "modfixes", "When various mods are installed and their blocks have broken particles, this tweak disables it.", true);
+        optimizeCraftTweakerNBTConverter = getBoolean("optimizeCraftTweakerNBTConverter", "modfixes", "When CraftTweaker is installed, optimize the backing map structure used by the NBT converter to use the same one that optimizeNBTTagCompoundBackingMap uses. This depends on the optimizeNBTTagCompoundBackingMap option to also be enabled.", true);
 
         fixAmuletHolderCapability = getBoolean("fixAmuletHolderCapability", "capability", "Fixes Astral Sorcery applying AmuletHolderCapability to large amount of ItemStacks when it isn't needed. This option will be ignored when Astral Sorcery isn't installed", true);
         delayItemStackCapabilityInit = getBoolean("delayItemStackCapabilityInit", "capability", "Delays ItemStack's capabilities from being initialized until they needed to be", true);

--- a/src/main/java/zone/rong/loliasm/core/LoliLateMixinLoader.java
+++ b/src/main/java/zone/rong/loliasm/core/LoliLateMixinLoader.java
@@ -22,7 +22,8 @@ public class LoliLateMixinLoader implements ILateMixinLoader {
                 "mixins.modfixes_b3m.json",
                 "mixins.searchtree_mod.json",
                 "mixins.modfixes_railcraft.json",
-                "mixins.modfixes_disable_broken_particles.json");
+                "mixins.modfixes_disable_broken_particles.json",
+                "mixins.modfixes_crafttweaker.json");
     }
 
     @Override
@@ -51,6 +52,11 @@ public class LoliLateMixinLoader implements ILateMixinLoader {
                 return LoliConfig.instance.efficientHashing && Loader.isModLoaded("railcraft");
             case "mixins.modfixes_disable_broken_particles.json":
                 return LoliConfig.instance.disableBrokenParticles;
+            case "mixins.modfixes_crafttweaker.json":
+                boolean optimizeMap = LoliConfig.instance.optimizeNBTTagCompoundBackingMap;
+                int mapThreshold = LoliConfig.instance.optimizeNBTTagCompoundMapThreshold;
+                boolean canonicalizeString = LoliConfig.instance.nbtBackingMapStringCanonicalization;
+                return ((optimizeMap && mapThreshold > 0) || canonicalizeString) && LoliConfig.instance.optimizeCraftTweakerNBTConverter && Loader.isModLoaded("crafttweaker");
         }
         return false;
     }

--- a/src/main/resources/mixins.modfixes_crafttweaker.json
+++ b/src/main/resources/mixins.modfixes_crafttweaker.json
@@ -1,0 +1,13 @@
+{
+  "package": "zone.rong.loliasm.common.modfixes.crafttweaker.mixins",
+  "refmap": "mixins.loliasm.refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "NBTConverterMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
This PR is to fix issues where the order of some items' NBT created by CraftTweaker's `NBTConverter` would not match that of NBT of normal items. Adds config option to toggle this mixin (still dependent on the other related config options). 

Specific use case is to fix the order of NBT of items (Thaumcraft vis crystals) shown in Modular Machinery Community Edition (MMCE) recipes. Here's an example of mismatched NBT order before this PR:
MMCE recipe with vis crystal -
<img width="805" height="605" alt="image3" src="https://github.com/user-attachments/assets/52d8d3c0-c52a-4e41-a50b-5ef87f3caac5" />
Regular obtainable vis crystal -
<img width="537" height="442" alt="image4" src="https://github.com/user-attachments/assets/b0e5030c-3cc1-4ead-90d2-4143bfd13485" />
With this PR, both vis crystals have the order of (1) key, (2) amount.
(Normally, with `optimizeNBTTagCompoundBackingMap` disabled, the order would be reversed like the MMCE recipe)