### PR TITLE
Fix AoA thrown weapons not working with delayItemStackCapabilityInit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ repositories {
 
 dependencies {
     embed 'me.nallar.whocalled:WhoCalled:1.1'
-    implementation 'zone.rong:mixinbooter:7.1'
+    implementation 'zone.rong:mixinbooter:10.7'
     implementation files('./etc/spark-forge-deobf.jar')
 
     compileOnly 'com.enderio.core:EnderCore:1.12.2-+'
@@ -115,6 +115,7 @@ dependencies {
     compileOnly rfg.deobf('curse.maven:time-speed-mod-221053:2991593')
     compileOnly rfg.deobf('curse.maven:gregtech-ce-unofficial-557242:3745499')
     compileOnly rfg.deobf("curse.maven:railcraft-51195:3853491")
+    compileOnly rfg.deobf("curse.maven:advent-of-ascension-311054:3054253")
 
     api ('org.spongepowered:mixin:0.8.3') {
         transitive = false

--- a/src/main/java/zone/rong/loliasm/LoliASM.java
+++ b/src/main/java/zone/rong/loliasm/LoliASM.java
@@ -14,7 +14,7 @@ import zone.rong.loliasm.proxy.CommonProxy;
 import java.util.*;
 import java.util.function.BiConsumer;
 
-@Mod(modid = "loliasm", name = "LoliASM", version = LoliLoadingPlugin.VERSION, dependencies = "required-after:mixinbooter@[4.2,);after:jei;after:spark@[1.5.2]")
+@Mod(modid = "loliasm", name = "LoliASM", version = LoliLoadingPlugin.VERSION, dependencies = "required-after:mixinbooter@[10.7,);after:jei;after:spark@[1.5.2]")
 public class LoliASM {
 
     @SidedProxy(modId = "loliasm", clientSide = "zone.rong.loliasm.proxy.ClientProxy", serverSide = "zone.rong.loliasm.proxy.CommonProxy")

--- a/src/main/java/zone/rong/loliasm/common/capability/aoa3/mixins/BaronGreatbladeMixin.java
+++ b/src/main/java/zone/rong/loliasm/common/capability/aoa3/mixins/BaronGreatbladeMixin.java
@@ -1,0 +1,18 @@
+package zone.rong.loliasm.common.capability.aoa3.mixins;
+
+import net.minecraft.item.ItemStack;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import net.tslat.aoa3.item.weapon.greatblade.BaronGreatblade;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = BaronGreatblade.class)
+public abstract class BaronGreatbladeMixin {
+    @ModifyExpressionValue(method = "attackEntity", at = @At(value = "NEW", target = "(Lnet/minecraft/item/Item;)Lnet/minecraft/item/ItemStack;", remap = false))
+    private ItemStack forceInitializeGrenadeTag(ItemStack original) {
+        // AoA uses this method as a hack to add their nbt, and this isn't called if delayItemStackCapabilityInit is enabled
+        original.getItem().initCapabilities(original, null);
+        return original;
+    }
+}

--- a/src/main/java/zone/rong/loliasm/common/capability/aoa3/mixins/CannonsMixin.java
+++ b/src/main/java/zone/rong/loliasm/common/capability/aoa3/mixins/CannonsMixin.java
@@ -1,0 +1,47 @@
+package zone.rong.loliasm.common.capability.aoa3.mixins;
+
+import net.minecraft.item.ItemStack;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import net.tslat.aoa3.item.weapon.cannon.AncientBomber;
+import net.tslat.aoa3.item.weapon.cannon.BlastCannon;
+import net.tslat.aoa3.item.weapon.cannon.BombLauncher;
+import net.tslat.aoa3.item.weapon.cannon.BoomBoom;
+import net.tslat.aoa3.item.weapon.cannon.BoomCannon;
+import net.tslat.aoa3.item.weapon.cannon.ErebonStickler;
+import net.tslat.aoa3.item.weapon.cannon.FloroRPG;
+import net.tslat.aoa3.item.weapon.cannon.LuxonStickler;
+import net.tslat.aoa3.item.weapon.cannon.MissileMaker;
+import net.tslat.aoa3.item.weapon.cannon.PlutonStickler;
+import net.tslat.aoa3.item.weapon.cannon.RPG;
+import net.tslat.aoa3.item.weapon.cannon.SelyanStickler;
+import net.tslat.aoa3.item.weapon.gun.BaseGun;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = {
+        AncientBomber.class,
+        BlastCannon.class,
+        BombLauncher.class,
+        BoomBoom.class,
+        BoomCannon.class,
+        ErebonStickler.class,
+        FloroRPG.class,
+        LuxonStickler.class,
+        MissileMaker.class,
+        PlutonStickler.class,
+        RPG.class,
+        SelyanStickler.class,
+}, remap = false)
+public abstract class CannonsMixin extends BaseGun {
+    private CannonsMixin(double dmg, int durability, int fireDelayTicks, float recoil) {
+        super(dmg, durability, fireDelayTicks, recoil);
+    }
+
+    @ModifyExpressionValue(method = "findAndConsumeAmmo", at = @At(value = "NEW", target = "(Lnet/minecraft/item/Item;)Lnet/minecraft/item/ItemStack;"))
+    private ItemStack forceInitializeTag(ItemStack original) {
+        // AoA uses this method as a hack to add their nbt, and this isn't called if delayItemStackCapabilityInit is enabled
+        initCapabilities(original, null);
+        return original;
+    }
+}

--- a/src/main/java/zone/rong/loliasm/common/capability/aoa3/mixins/ThrownWeaponsMixin.java
+++ b/src/main/java/zone/rong/loliasm/common/capability/aoa3/mixins/ThrownWeaponsMixin.java
@@ -1,0 +1,37 @@
+package zone.rong.loliasm.common.capability.aoa3.mixins;
+
+import net.minecraft.item.ItemStack;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import net.tslat.aoa3.item.weapon.thrown.BaseThrownWeapon;
+import net.tslat.aoa3.item.weapon.thrown.Chakram;
+import net.tslat.aoa3.item.weapon.thrown.GooBall;
+import net.tslat.aoa3.item.weapon.thrown.Grenade;
+import net.tslat.aoa3.item.weapon.thrown.Hellfire;
+import net.tslat.aoa3.item.weapon.thrown.RunicBomb;
+import net.tslat.aoa3.item.weapon.thrown.SliceStar;
+import net.tslat.aoa3.item.weapon.thrown.Vulkram;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = {
+        Chakram.class,
+        GooBall.class,
+        Grenade.class,
+        Hellfire.class,
+        RunicBomb.class,
+        SliceStar.class,
+        Vulkram.class
+}, remap = false)
+public abstract class ThrownWeaponsMixin extends BaseThrownWeapon {
+    private ThrownWeaponsMixin(double dmg, int fireDelayTicks) {
+        super(dmg, fireDelayTicks);
+    }
+
+    @ModifyExpressionValue(method = "findAndConsumeAmmo", at = @At(value = "NEW", target = "(Lnet/minecraft/item/Item;)Lnet/minecraft/item/ItemStack;"))
+    private ItemStack forceInitializeTag(ItemStack original) {
+        // AoA uses this method as a hack to add their nbt, and this isn't called if delayItemStackCapabilityInit is enabled
+        initCapabilities(original, null);
+        return original;
+    }
+}

--- a/src/main/java/zone/rong/loliasm/core/LoliLateMixinLoader.java
+++ b/src/main/java/zone/rong/loliasm/core/LoliLateMixinLoader.java
@@ -23,7 +23,8 @@ public class LoliLateMixinLoader implements ILateMixinLoader {
                 "mixins.searchtree_mod.json",
                 "mixins.modfixes_railcraft.json",
                 "mixins.modfixes_disable_broken_particles.json",
-                "mixins.modfixes_crafttweaker.json");
+                "mixins.modfixes_crafttweaker.json",
+                "mixins.capability_aoa3.json");
     }
 
     @Override
@@ -57,6 +58,8 @@ public class LoliLateMixinLoader implements ILateMixinLoader {
                 int mapThreshold = LoliConfig.instance.optimizeNBTTagCompoundMapThreshold;
                 boolean canonicalizeString = LoliConfig.instance.nbtBackingMapStringCanonicalization;
                 return ((optimizeMap && mapThreshold > 0) || canonicalizeString) && LoliConfig.instance.optimizeCraftTweakerNBTConverter && Loader.isModLoaded("crafttweaker");
+            case "mixins.capability_aoa3.json":
+                return LoliConfig.instance.delayItemStackCapabilityInit && Loader.isModLoaded("aoa3");
         }
         return false;
     }

--- a/src/main/java/zone/rong/loliasm/vanillafix/bugfixes/mixins/MixinEntityPlayerMP.java
+++ b/src/main/java/zone/rong/loliasm/vanillafix/bugfixes/mixins/MixinEntityPlayerMP.java
@@ -1,5 +1,6 @@
 package zone.rong.loliasm.vanillafix.bugfixes.mixins;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -13,7 +14,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import zone.rong.mixinextras.injector.ModifyReturnValue;
 
 @Mixin(EntityPlayerMP.class)
 public abstract class MixinEntityPlayerMP extends EntityPlayer {

--- a/src/main/resources/mixins.capability_aoa3.json
+++ b/src/main/resources/mixins.capability_aoa3.json
@@ -5,6 +5,8 @@
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "BaronGreatbladeMixin",
+    "CannonsMixin",
     "ThrownWeaponsMixin"
   ]
 }

--- a/src/main/resources/mixins.capability_aoa3.json
+++ b/src/main/resources/mixins.capability_aoa3.json
@@ -1,0 +1,10 @@
+{
+  "package": "zone.rong.loliasm.common.capability.aoa3.mixins",
+  "refmap": "mixins.loliasm.refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "ThrownWeaponsMixin"
+  ]
+}


### PR DESCRIPTION
AoA uses capability init as a hack to set their NBT for thrown weapons [here](https://github.com/Tslat/Advent-Of-Ascension/blob/1.12.2/source/item/weapon/gun/BaseGun.java#L183-L190). When trying to use the thrown weapons, it would fail to find the ammo in the player's inventory because the ammo is compared to a reference itemstack [here](https://github.com/Tslat/Advent-Of-Ascension/blob/1.12.2/source/item/weapon/thrown/Chakram.java#L50) that assumes `BaseGun#initCapabilities()` was called, which it does not with `delayItemStackCapabilityInit=true`.
Fixes the issue by calling `initCapabilities` on the reference stack before comparing. The item in the inventory seems to always have this tag already. I believe only thrown weapons and grenade-related weapons have this issue.

Fixes #151.
Also bumps MixinBooter version to 10.7 (old one wasn't recognizing `ModifyExpressionValue` code completion).