### PR TITLE
Support modern Spark without invoking legacy profiler API

### DIFF
--- a/src/main/java/zone/rong/loliasm/LoliASM.java
+++ b/src/main/java/zone/rong/loliasm/LoliASM.java
@@ -14,7 +14,7 @@ import zone.rong.loliasm.proxy.CommonProxy;
 import java.util.*;
 import java.util.function.BiConsumer;
 
-@Mod(modid = "loliasm", name = "LoliASM", version = LoliLoadingPlugin.VERSION, dependencies = "required-after:mixinbooter@[10.7,);after:jei;after:spark@[1.5.2]")
+@Mod(modid = "loliasm", name = "LoliASM", version = LoliLoadingPlugin.VERSION, dependencies = "required-after:mixinbooter@[10.7,);after:jei;after:spark")
 public class LoliASM {
 
     @SidedProxy(modId = "loliasm", clientSide = "zone.rong.loliasm.proxy.ClientProxy", serverSide = "zone.rong.loliasm.proxy.CommonProxy")

--- a/src/main/java/zone/rong/loliasm/common/internal/mixins/LoadControllerMixin.java
+++ b/src/main/java/zone/rong/loliasm/common/internal/mixins/LoadControllerMixin.java
@@ -53,7 +53,7 @@ public abstract class LoadControllerMixin {
     @Inject(method = "propogateStateMessage", at = @At("HEAD"))
     private void injectBeforeDistributingState(FMLEvent stateEvent, CallbackInfo ci) {
         if (hasSpark == null) {
-            hasSpark = Loader.isModLoaded("spark");
+            hasSpark = Loader.isModLoaded("spark") && loliasm$hasLegacySparkProfilerApi();
         }
         if (hasSpark) {
             if (stateEvent instanceof FMLStateEvent) {
@@ -119,6 +119,16 @@ public abstract class LoadControllerMixin {
                     LoliSparker.start("finalizing");
                 }
             }
+        }
+    }
+
+    @Unique
+    private static boolean loliasm$hasLegacySparkProfilerApi() {
+        try {
+            Class.forName("me.lucko.spark.common.sampler.Sampler").getMethod("stop");
+            return true;
+        } catch (ReflectiveOperationException | LinkageError ignored) {
+            return false;
         }
     }
 


### PR DESCRIPTION
## Problem
LoliASM 5.33 has an optional load-stage profiler compiled against the legacy Spark sampler API, and its mod dependency metadata also pins Spark exactly to `1.5.2`.

Modern Spark builds still provide the `spark` mod, but the sampler API changed. This makes LoliASM's embedded profiler path incompatible even though standalone Spark itself works.

## Fix
- Relax the optional Spark dependency from the exact `1.5.2` pin to `after:spark`.
- Keep the legacy `LoliSparker` implementation intact, but enable it only when the legacy no-argument `Sampler#stop()` API is present.

Compatible legacy Spark versions keep LoliASM's load-stage profiling. Modern Spark versions remain loaded and functional while LoliASM skips only its incompatible embedded profiler.

## Validation
- `compileJava` passes on the exact upstream base.
- Java 8 API-gate harness: legacy sampler API -> enabled; Spark Unforged 1.11.140 -> skipped.
- Runtime-tested in Minecraft 1.12.2 with Spark Unforged 1.11.140 in a 488-JAR integration set.
- World save/reload and clean shutdown were verified.
- The runtime-tested candidate used the equivalent modern-Spark behavior: exact Spark pin removed and the incompatible embedded profiler disabled.

Base branch reviewed: `master`
Base commit: `52ba4f9ac30b22b242689e4e6c59212d36fcd9c8`